### PR TITLE
Make Euro area/EU27 rename regex-based, not exact-string

### DIFF
--- a/Eurostat.py
+++ b/Eurostat.py
@@ -4,62 +4,62 @@ import pandas as pd
 import os
 os.makedirs('data', exist_ok=True)
 rename_dict = {
-    'Euro area (EA11-1999, EA12-2001, EA13-2007, EA15-2008, EA16-2009, EA17-2011, EA18-2014, EA19-2015, EA20-2023)': 'Euro area',
-    'European Union (EU6-1958, EU9-1973, EU10-1981, EU12-1986, EU15-1995, EU25-2004, EU27-2007, EU28-2013, EU27-2020)': 'EU27'
+    r'^Euro area \(.*\)$': 'Euro area',
+    r'^European Union \(.*\)$': 'EU27'
 }
 
 #Euro Area Flash Estimate
 dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=CP00&geo=EA&geo=BE&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=MT&geo=NL&geo=AT&geo=PT&geo=SI&geo=SK&geo=FI')
 df = dataset.write('dataframe')
-df.replace(rename_dict, inplace=True)
+df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Geopolitical entity (reporting)', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_EA_HICP_Time.csv', index=True)
 
 #Europe Latest Data
 dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=CP00&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
 df = dataset.write('dataframe')
-df.replace(rename_dict, inplace=True)
+df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Geopolitical entity (reporting)', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_All_HICP_Time.csv', index=True)
 
 #EU27 Main Components
 dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=CP00&geo=EU&coicop=FOOD&coicop=IGD_NNRG&coicop=NRG&coicop=SERV')
 df = dataset.write('dataframe')
-df.replace(rename_dict, inplace=True)
+df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Classification of individual consumption by purpose (COICOP)', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_EU27_Components_Time.csv', index=True)
 
 #EA Main Components
 dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=CP00&geo=EA&coicop=FOOD&coicop=IGD_NNRG&coicop=NRG&coicop=SERV')
 df = dataset.write('dataframe')
-df.replace(rename_dict, inplace=True)
+df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Classification of individual consumption by purpose (COICOP)', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_EA_Components_Time.csv', index=True)
 
 #Europe Food 
 dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=FOOD&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
 df = dataset.write('dataframe')
-df.replace(rename_dict, inplace=True)
+df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Geopolitical entity (reporting)', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_All_Food_Time.csv', index=True)
 
 #Europe Services 
 dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=SERV&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
 df = dataset.write('dataframe')
-df.replace(rename_dict, inplace=True)
+df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Geopolitical entity (reporting)', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_All_Services_Time.csv', index=True)
 
 #Europe Energy 
 dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=NRG&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
 df = dataset.write('dataframe')
-df.replace(rename_dict, inplace=True)
+df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Geopolitical entity (reporting)', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_All_Energy_Time.csv', index=True)
 
 #Europe Non-energy industrial goods 
 dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=IGD_NNRG&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
 df = dataset.write('dataframe')
-df.replace(rename_dict, inplace=True)
+df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Geopolitical entity (reporting)', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_All_Non_Energy_Goods_Time.csv', index=True)


### PR DESCRIPTION
## Summary
- Eurostat now appends a new EA/EU membership vintage code to the aggregate row label (currently `...EA20-2023, EA21-2026)`), so the old exact-string `rename_dict` silently stopped matching and left the raw Eurostat label in the CSV instead of the clean `Euro area`/`EU27` names.
- The Datawrapper charts (e.g. Vz1am "Euro Area Inflation") key their `column-format` ignore-lists off the exact string `"Euro area"`, so this was about to break the euro-area line/summary row once the latest data got merged.
- Switched both replacements to a regex prefix match (`^Euro area \(.*\)$` / `^European Union \(.*\)$`) so future vintage-code additions from Eurostat don't break this again.

## Test plan
- [ ] Re-run `Eurostat.yml` after merge and confirm the `Euro area`/`EU27` rows in `data/Eurostat_Inflation_All_HICP_Time.csv` and `data/Eurostat_Inflation_EA_HICP_Time.csv` are clean names, not the long Eurostat label