### PR TITLE
Switch Eurostat.py to prc_hicp_minr (prc_hicp_manr is discontinued)

### DIFF
--- a/Eurostat.py
+++ b/Eurostat.py
@@ -9,56 +9,56 @@ rename_dict = {
 }
 
 #Euro Area Flash Estimate
-dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=CP00&geo=EA&geo=BE&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=MT&geo=NL&geo=AT&geo=PT&geo=SI&geo=SK&geo=FI')
+dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_minr?lang=en&lastTimePeriod=61&unit=RCH_A&coicop18=TOTAL&geo=EA&geo=BE&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=MT&geo=NL&geo=AT&geo=PT&geo=SI&geo=SK&geo=FI')
 df = dataset.write('dataframe')
 df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Geopolitical entity (reporting)', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_EA_HICP_Time.csv', index=True)
 
 #Europe Latest Data
-dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=CP00&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
+dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_minr?lang=en&lastTimePeriod=61&unit=RCH_A&coicop18=TOTAL&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
 df = dataset.write('dataframe')
 df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Geopolitical entity (reporting)', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_All_HICP_Time.csv', index=True)
 
 #EU27 Main Components
-dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=CP00&geo=EU&coicop=FOOD&coicop=IGD_NNRG&coicop=NRG&coicop=SERV')
+dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_minr?lang=en&lastTimePeriod=61&unit=RCH_A&coicop18=TOTAL&geo=EU&coicop18=FOOD&coicop18=IGD_NNRG&coicop18=NRG&coicop18=SERV')
 df = dataset.write('dataframe')
 df.replace(rename_dict, regex=True, inplace=True)
-df_new = df.pivot(index='Classification of individual consumption by purpose (COICOP)', columns='Time', values='value')
+df_new = df.pivot(index='Classification of individual consumption by purpose (COICOP) - 2018', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_EU27_Components_Time.csv', index=True)
 
 #EA Main Components
-dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=CP00&geo=EA&coicop=FOOD&coicop=IGD_NNRG&coicop=NRG&coicop=SERV')
+dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_minr?lang=en&lastTimePeriod=61&unit=RCH_A&coicop18=TOTAL&geo=EA&coicop18=FOOD&coicop18=IGD_NNRG&coicop18=NRG&coicop18=SERV')
 df = dataset.write('dataframe')
 df.replace(rename_dict, regex=True, inplace=True)
-df_new = df.pivot(index='Classification of individual consumption by purpose (COICOP)', columns='Time', values='value')
+df_new = df.pivot(index='Classification of individual consumption by purpose (COICOP) - 2018', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_EA_Components_Time.csv', index=True)
 
-#Europe Food 
-dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=FOOD&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
+#Europe Food
+dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_minr?lang=en&lastTimePeriod=61&unit=RCH_A&coicop18=FOOD&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
 df = dataset.write('dataframe')
 df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Geopolitical entity (reporting)', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_All_Food_Time.csv', index=True)
 
-#Europe Services 
-dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=SERV&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
+#Europe Services
+dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_minr?lang=en&lastTimePeriod=61&unit=RCH_A&coicop18=SERV&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
 df = dataset.write('dataframe')
 df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Geopolitical entity (reporting)', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_All_Services_Time.csv', index=True)
 
-#Europe Energy 
-dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=NRG&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
+#Europe Energy
+dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_minr?lang=en&lastTimePeriod=61&unit=RCH_A&coicop18=NRG&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
 df = dataset.write('dataframe')
 df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Geopolitical entity (reporting)', columns='Time', values='value')
 df_new.to_csv('data/Eurostat_Inflation_All_Energy_Time.csv', index=True)
 
-#Europe Non-energy industrial goods 
-dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?lang=en&lastTimePeriod=61&coicop=IGD_NNRG&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
+#Europe Non-energy industrial goods
+dataset = pyjstat.Dataset.read('https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_minr?lang=en&lastTimePeriod=61&unit=RCH_A&coicop18=IGD_NNRG&geo=EU&geo=EA&geo=BE&geo=BG&geo=CZ&geo=DK&geo=DE&geo=EE&geo=IE&geo=EL&geo=ES&geo=FR&geo=HR&geo=IT&geo=CY&geo=LV&geo=LT&geo=LU&geo=HU&geo=MT&geo=NL&geo=AT&geo=PL&geo=PT&geo=RO&geo=SI&geo=SK&geo=FI&geo=SE&geo=NO&geo=IS&geo=CH')
 df = dataset.write('dataframe')
 df.replace(rename_dict, regex=True, inplace=True)
 df_new = df.pivot(index='Geopolitical entity (reporting)', columns='Time', values='value')


### PR DESCRIPTION
## Summary
- Eurostat discontinued `prc_hicp_manr` and replaced it with `prc_hicp_minr`. The old dataset stopped updating after 2026-02-06 (frozen at December 2025) even though our fetch job kept running successfully every time it was triggered — it was silently returning increasingly stale data.
- Switched all 8 pulls to the new dataset: `coicop=` → `coicop18=`, `CP00` → `TOTAL`, added required `unit=RCH_A`, and updated the components pivot's index label to match the renamed dimension (`...(COICOP) - 2018`).
- Verified locally: all 8 pulls succeed, data now extends to 2026-06 (vs 2025-12 before), and the existing Euro area/EU27 regex rename still matches correctly against the new dataset's geo labels.

## Test plan
- [ ] Merge, re-run `Eurostat.yml`, confirm the new branch's CSVs extend through the latest available month and `Euro area`/`EU27` rows are clean